### PR TITLE
Add a Archlinux PKGBUILD

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -23,11 +23,10 @@ pkgver() {
 }
 
 build(){
-  export GOPATH="${srcdir}/gopath"
   cd "${srcdir}/run"
   go build \
     -trimpath \
-    -ldflags "-extldflags $LDFLAGS" 
+    -ldflags "-extldflags $LDFLAGS" .
 }
 
 package(){

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -4,10 +4,13 @@ pkgname=run
 pkgver=0.1
 pkgrel=1
 pkgdesc="Easily manage and invoke small scripts and wrappers"
-arch=('x86_64')
+arch=('i686' 'x86_64')
 url="https://github.com/TekWizely/run"
 license=('MIT')
-makedepends=('go-pie')
+makedepends=(
+  'go-pie'
+  'git'
+)
 source=("git+https://github.com/TekWizely/run.git")
 sha256sums=('SKIP')
 
@@ -20,6 +23,7 @@ pkgver() {
 }
 
 build(){
+  export GOPATH="${srcdir}/gopath"
   cd "${srcdir}/run"
   go build \
     -trimpath \

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,0 +1,33 @@
+# Maintainer: None yet
+
+pkgname=run
+pkgver=0.1
+pkgrel=1
+pkgdesc="Easily manage and invoke small scripts and wrappers"
+arch=('x86_64')
+url="https://github.com/TekWizely/run"
+license=('MIT')
+makedepends=('go-pie')
+source=("git+https://github.com/TekWizely/run.git")
+sha256sums=('SKIP')
+
+pkgver() {
+  cd "${srcdir}/run"
+  ( set -o pipefail
+    git describe --long 2>/dev/null | sed 's/\([^-]*-g\)/r\1/;s/-/./g' ||
+    printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+  )
+}
+
+build(){
+  cd "${srcdir}/run"
+  go build \
+    -trimpath \
+    -ldflags "-extldflags $LDFLAGS" 
+}
+
+package(){
+  cd "${srcdir}/run"
+  install -Dm755 run "${pkgdir}/usr/bin/run"
+  install -Dm644 LICENSE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+}

--- a/deployments/aur/PKGBUILD
+++ b/deployments/aur/PKGBUILD
@@ -1,36 +1,39 @@
-# Maintainer: None yet
+# Maintainer: Mendel Greenberg <mendel at chabad360 dot com>
 
-pkgname=run
-pkgver=0.1
+pkgname=run-git
+_pkgname=run
+pkgver=v0.7.0.r8.g0d33f74
 pkgrel=1
 pkgdesc="Easily manage and invoke small scripts and wrappers"
 arch=('i686' 'x86_64')
 url="https://github.com/TekWizely/run"
 license=('MIT')
+provides=('run')
 makedepends=(
-  'go-pie'
+  'go'
   'git'
 )
 source=("git+https://github.com/TekWizely/run.git")
 sha256sums=('SKIP')
 
 pkgver() {
-  cd "${srcdir}/run"
-  ( set -o pipefail
-    git describe --long 2>/dev/null | sed 's/\([^-]*-g\)/r\1/;s/-/./g' ||
-    printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
-  )
+  cd "${srcdir}/${_pkgname}"
+  git describe --tags --long 2>/dev/null | sed 's/\([^-]*-g\)/r\1/;s/-/./g'
 }
 
 build(){
-  cd "${srcdir}/run"
+  cd "${srcdir}/${_pkgname}"
+  export GOCACHE="${srcdir}/cache"
+  export GOPATH="${srcdir}/gopath"
+  go mod vendor
   go build \
+    -mod=vendor \
     -trimpath \
     -ldflags "-extldflags $LDFLAGS" .
 }
 
 package(){
-  cd "${srcdir}/run"
+  cd "${srcdir}/${_pkgname}"
   install -Dm755 run "${pkgdir}/usr/bin/run"
   install -Dm644 LICENSE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
 }


### PR DESCRIPTION
This would be a first step for making binary packages generally available (although in this current state you'd push just the `PKGBUILD` and its corresponding `.SRCINFO` to the Archlinux [aur](https://aur.archlinux.org) and people would download the `PKGBUILD` and build it), you can use `makepkg` (on arch) to build a `.pkg.tar.xz` that would go with a release.