### PR TITLE
Allows EOF at end of last command script line

### DIFF
--- a/internal/lexer/lexer.go
+++ b/internal/lexer/lexer.go
@@ -686,7 +686,7 @@ func lexCmdScriptLine(_ *LexContext, l *lexer.Lexer) LexFn {
 	// We have a script line
 	// Consume the full line, including eol/eof
 	//
-	for !matchNewline(l) {
+	for !matchNewlineOrEOF(l) {
 		l.Next()
 	}
 	l.EmitToken(TokenScriptLine)


### PR DESCRIPTION
The existing comment mentioned to EOF/ EOL but the wrong check method was used.

Fixes #1 