### PR TITLE
Passes all args to script if no options defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ In run, the entire script is executed within a single sub-shell.
  - [Command-Line Options](#command-line-options)
    - [Boolean (Flag) Options](#boolean-flag-options)
    - [Getting `-h` & `--help` For Free](#getting--h----help-for-free)
+   - [Passing Options Directly Through to the Command Script](#passing-options-directly-through-to-the-command-script)
  - [Run Tool Help](#run-tool-help)
  - [Using an Alternative Runfile](#using-an-alternative-runfile)
  - [Runfile Variables](#runfile-variables)
@@ -169,7 +170,7 @@ hello:
 
 _output_
 
-```shell
+```
 $ run list
 
 Commands:
@@ -298,14 +299,76 @@ Hello, World
 
 #### Getting `-h` & `--help` For Free
 
-If your command does not explicitly configure options `-h` or `--help`, then they are automatically registered to display the command's help text.
+If your command defines one or more options, but does not explicitly configure options `-h` or `--help`, then they are automatically registered to display the command's help text.
 
+_Runfile_
 ```
+##
+# Hello world example.
+# Prints "Hello, world".
+hello:
+  echo "Hello, world"
+```
+
+_output_
+```
+$ run hello -h
 $ run hello --help
 
 hello:
-  ...
+  Hello world example.
+  Prints "Hello, world".
 ```
+
+#### Passing Options Directly Through to the Command Script
+
+If your command does not define any options within the Runfile, then run will pass all command line arguments directly through to the command script.
+
+_Runfile_
+```
+##
+# Echo example
+# Prints the arguments passed into the script
+#
+echo:
+  echo script arguments = "${@}"
+```
+
+_output_
+```
+$ run echo -h --help Hello Newman
+
+script arguments = -h --help Hello Newman
+```
+
+NOTE: As you likely surmised, help options (`-h` & `--help`) are not automatically registered when the command does not define any other options.
+
+##### What if My Command Script DOES Define Options?
+
+If your command script does define one or more options within the Runfile, you can still pass options directly through to the command script, but the syntax is a bit different:
+
+_Runfile_
+```
+##
+# Echo example
+# Prints the arguments passed into the script
+# Use -- to separate run options from script options
+# OPTION ARG -a <arg> Contrived argument
+#
+echo:
+  echo ARG = "${ARG}"
+  echo script arguments = "${@}"
+```
+
+_output_
+```
+$ run echo -a myarg -- -h --help Hello Newman
+
+ARG = myarg
+script arguments = -h --help Hello Newman
+```
+
+Notice the `'--'` in the argument list - Run will stop parsing options when it encounters the `'--'` and pass the rest of the arguments through to the command script.
 
 -----------------
 ### Run Tool Help
@@ -372,7 +435,7 @@ By default, variables are local to the runfile and are not part of your command'
 For example, you can access them within your command's description:
 
 ```
-$ run hello -h
+$ run help hello
 
 hello:
   Hello world example.
@@ -425,7 +488,7 @@ hello:
 
 _help output_
 ```
-$ run hello -h
+$ run help hello
 
 hello:
   Hello world example.
@@ -743,6 +806,12 @@ runfile.sh:
   Hello example using main mode
 
 ```
+
+#### Help options
+
+In main mode, help options (`-h` & `--help`) are automatically configured, even if no other options are defined.
+
+This means you will need to use `--` in order to pass options through to the main script.
 
 -------------
 ## Installing

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,6 +26,14 @@ const DefaultShell = "sh"
 //
 var Me string
 
+// ShebangMode treats the Runfile as the executable
+//
+var ShebangMode bool
+
+// MainMode extends ShebangMode by auto-invoking the main command
+//
+var MainMode bool
+
 // ErrOut is where logs and errors are sent to (generally stderr).
 //
 var ErrOut io.Writer

--- a/internal/runfile/command.go
+++ b/internal/runfile/command.go
@@ -186,8 +186,9 @@ func (a *boolOpt) IsBoolFlag() bool {
 //
 func evaluateCmdOpts(cmd *RunCmd, args []string) []string {
 	// If no options defined, pass all args through to command script
+	// NOTE: For MainMode we still define options, mainly for --help
 	//
-	if len(cmd.Config.Opts) == 0 {
+	if len(cmd.Config.Opts) == 0 && !config.MainMode {
 		return args
 	}
 	flags := flag.NewFlagSet(cmd.Name, flag.ExitOnError)

--- a/internal/runfile/command.go
+++ b/internal/runfile/command.go
@@ -185,6 +185,11 @@ func (a *boolOpt) IsBoolFlag() bool {
 // evaluateCmdOpts
 //
 func evaluateCmdOpts(cmd *RunCmd, args []string) []string {
+	// If no options defined, pass all args through to command script
+	//
+	if len(cmd.Config.Opts) == 0 {
+		return args
+	}
 	flags := flag.NewFlagSet(cmd.Name, flag.ExitOnError)
 	// Invoked if error parsing arguments.
 	//

--- a/main.go
+++ b/main.go
@@ -21,11 +21,7 @@ const (
 )
 
 var (
-	inputFile   string
-	shebangMode bool
-	mainMode    bool
-)
-var (
+	inputFile string
 	hidePanic = false // Hide full trace on panics
 )
 
@@ -91,11 +87,11 @@ func main() {
 			shebangFile = os.Args[1]
 			os.Args = append(os.Args[:1], os.Args[2:]...)
 		}
-		shebangMode = len(shebangFile) > 0 && path.Base(shebangFile) != runfileDefault
+		config.ShebangMode = len(shebangFile) > 0 && path.Base(shebangFile) != runfileDefault
 	}
 	// In shebang mode, we defer parsing args until we know if we are in "main" mode
 	//
-	if shebangMode {
+	if config.ShebangMode {
 		config.Me = path.Base(shebangFile) // Script Name = executable Name for Help
 		inputFile = shebangFile            // shebang file = runfile
 		config.EnableRunfileOverride = false
@@ -161,13 +157,13 @@ func main() {
 	}
 	// In shebang mode, if only 1 runfile command defined, named "main", default to it directly
 	//
-	mainMode = shebangMode &&
+	config.MainMode = config.ShebangMode &&
 		len(config.CommandList) == (builtinCnt+1) &&
 		strings.EqualFold(config.CommandList[builtinCnt].Name, "main")
 	// Determine which command to run
 	//
 	var cmdName string
-	if mainMode {
+	if config.MainMode {
 		// In main mode, we defer parsing args to the command
 		//
 		os.Args = os.Args[1:] // Discard 'Me'
@@ -176,7 +172,7 @@ func main() {
 	} else {
 		// If we deferred parsing args, now is the time
 		//
-		if shebangMode {
+		if config.ShebangMode {
 			parseArgs()
 		}
 		if len(os.Args) > 0 {


### PR DESCRIPTION
Short-circuits option parsing when no options defined, passing all args to command script.

This implies that `-h|--help` is only supported when the command explicitly defines one or more options.

Fixes #3 

---
TODO Before Merging:
 * ~~Update the README for this change.~~
