### PR TITLE
Adds support for '-' in command names

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ In run, the entire script is executed within a single sub-shell.
 ## Examples
 
  - [Simple Command Definitions](#simple-command-definitions)
+   - [Naming Commands](#naming-commands)
  - [Simple Title Definitions](#simple-title-definitions)
  - [Title & Description](#title--description)
  - [Arguments](#arguments)
@@ -119,6 +120,87 @@ _invoke hello command_
 $ run hello
 
 Hello, world
+```
+
+#### Naming Commands
+
+Run accepts the following pattern for command names:
+
+```
+alpha ::= 'a' .. 'z' | 'A' .. 'Z'
+digit ::= '0' .. '9'
+
+CMD_NAME ::= [ alpha | '_' ] ( [ alpha | digit | '_' | '-' ] )*
+```
+
+Some examples:
+* `hello`
+* `hello_world`
+* `hello-world`
+* `HelloWorld`
+
+##### Case Sensitivity
+
+###### Invoking Commands
+
+When invoking commands, run treats the command name as case-insensitive:
+
+_Runfile_
+```
+Hello-World:
+  echo "Hello, world"
+```
+
+_output_
+```
+$ run Hello-World
+$ run Hello-world
+$ run hello-world
+
+Hello, world
+```
+
+###### Displaying Help
+
+When displaying help text, run treats the command name as case-sensitive, displaying the command name as it is defined:
+
+_list commands_
+
+```
+$ run list
+
+Commands:
+  ..
+  Hello-World
+  ...
+```
+
+_show help for Hello-World command_
+```
+$ run help Hello-World
+
+Hello-World: No help available.
+```
+
+###### Duplicate Command Names
+
+When registering commands, run treats the command name as case-insensitive, generating an error if a command name is defined multiple times:
+
+_Runfile_
+```
+hello-world:
+  echo "Hello, world"
+
+Hello-World:
+  echo "Hello, world"
+```
+
+_list commands_
+
+```
+$ run list
+
+panic: Duplicate command: hello-world
 ```
 
 ----------------------------

--- a/internal/lexer/lexer.go
+++ b/internal/lexer/lexer.go
@@ -124,13 +124,16 @@ func LexMain(_ *LexContext, l *lexer.Lexer) LexFn {
 	//
 	case matchDotID(l):
 		l.EmitToken(TokenDotID)
-	// ID
+	// Keyword / ID / DashID
 	//
-	case matchID(l):
+	case matchDashID(l):
 		name := strings.ToUpper(l.PeekToken())
-		if t, ok := mainTokens[name]; ok {
-			l.EmitType(t)
-		} else {
+		switch {
+		case isMainToken(name):
+			l.EmitType(mainTokens[name])
+		case strings.ContainsRune(name, runeDash):
+			l.EmitToken(TokenDashID)
+		default:
 			l.EmitToken(TokenID)
 		}
 	// Unknown
@@ -202,7 +205,7 @@ func LexVarRef(_ *LexContext, l *lexer.Lexer) LexFn {
 	l.EmitType(TokenLBrace)
 	// Variable Name
 	//
-	matchZeroOrMore(l, isAlphaNumDotUnder)
+	matchZeroOrMore(l, isAlphaNumUnderDot)
 	l.EmitToken(TokenRunes) // Could be empty
 	// Close Brace
 	//
@@ -753,4 +756,10 @@ func matchDotID(l *lexer.Lexer) (ok bool) {
 //
 func matchID(l *lexer.Lexer) bool {
 	return matchOne(l, isAlphaUnder) && matchZeroOrMore(l, isAlphaNumUnder)
+}
+
+// matchDashID
+//
+func matchDashID(l *lexer.Lexer) bool {
+	return matchOne(l, isAlphaUnder) && matchZeroOrMore(l, isAlphaNumUnderDash)
 }

--- a/internal/lexer/runes.go
+++ b/internal/lexer/runes.go
@@ -48,6 +48,13 @@ var mainTokens = map[string]token.Type{
 	"EXPORT":  TokenExport,
 }
 
+// isMainToken exists soley to appease go-critic
+//
+func isMainToken(s string) bool {
+	_, ok := mainTokens[s]
+	return ok
+}
+
 // Cmd Config Tokens
 //
 var cmdConfigTokens = map[string]token.Type{
@@ -74,8 +81,12 @@ func isAlphaNumUnder(r rune) bool {
 	return (r >= '0' && r <= '9') || (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || r == '_'
 }
 
-func isAlphaNumDotUnder(r rune) bool {
+func isAlphaNumUnderDot(r rune) bool {
 	return (r >= '0' && r <= '9') || (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || r == '_' || r == '.'
+}
+
+func isAlphaNumUnderDash(r rune) bool {
+	return (r >= '0' && r <= '9') || (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || r == '_' || r == '-'
 }
 
 func isHash(r rune) bool {

--- a/internal/lexer/tokens.go
+++ b/internal/lexer/tokens.go
@@ -11,6 +11,7 @@ const (
 
 	TokenID
 	TokenDotID
+	TokenDashID
 
 	TokenColon
 	TokenComma

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -569,7 +569,7 @@ func expectDQString(ctx *parseContext, p *parser.Parser) *ast.ScopeValueNodeList
 	panic("expecting TokenDoubleQuote ('\"')")
 }
 
-// tryMatchCmdHeaderWithShell matches [ [ 'CMD' ] CMD_ID ( '(' ID ')' )? ( ':' | '{' ) ]
+// tryMatchCmdHeaderWithShell matches [ [ 'CMD' ] DASH_ID ( '(' ID ')' )? ( ':' | '{' ) ]
 //
 func tryMatchCmdHeaderWithShell(ctx *parseContext, p *parser.Parser) (string, string, bool) {
 	expectCommand := tryPeekType(p, lexer.TokenCommand)

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -569,7 +569,7 @@ func expectDQString(ctx *parseContext, p *parser.Parser) *ast.ScopeValueNodeList
 	panic("expecting TokenDoubleQuote ('\"')")
 }
 
-// tryMatchCmdHeaderWithShell matches [ [ 'CMD' ] ID ( '(' ID ')' )? ( ':' | '{' ) ]
+// tryMatchCmdHeaderWithShell matches [ [ 'CMD' ] CMD_ID ( '(' ID ')' )? ( ':' | '{' ) ]
 //
 func tryMatchCmdHeaderWithShell(ctx *parseContext, p *parser.Parser) (string, string, bool) {
 	expectCommand := tryPeekType(p, lexer.TokenCommand)
@@ -577,7 +577,8 @@ func tryMatchCmdHeaderWithShell(ctx *parseContext, p *parser.Parser) (string, st
 		expectTokenType(p, lexer.TokenCommand, "Expecting TokenCommand")
 	} else {
 		expectCommand =
-			tryPeekTypes(p, lexer.TokenID, lexer.TokenColon) ||
+			tryPeekType(p, lexer.TokenDashID) ||
+				tryPeekTypes(p, lexer.TokenID, lexer.TokenColon) ||
 				tryPeekTypes(p, lexer.TokenID, lexer.TokenLParen) ||
 				tryPeekTypes(p, lexer.TokenID, lexer.TokenLBrace)
 	}
@@ -586,7 +587,12 @@ func tryMatchCmdHeaderWithShell(ctx *parseContext, p *parser.Parser) (string, st
 	}
 	// Name
 	//
-	name := expectTokenType(p, lexer.TokenID, "Expecting TokenID").Value()
+	var name string
+	if tryPeekType(p, lexer.TokenDashID) {
+		name = expectTokenType(p, lexer.TokenDashID, "Expecting command name").Value()
+	} else {
+		name = expectTokenType(p, lexer.TokenID, "Expecting command name").Value()
+	}
 	// Shell
 	//
 	shell := ""


### PR DESCRIPTION
This change enables command names to contain dash `'-'` characters, after the first character.

Docs are updated to reflect the change and also clarify a few other aspects of command naming.

Fixes #7 