### PR TITLE
Adds auto-detection for "#!" scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -762,7 +762,7 @@ Any executor that is on the `PATH`, can be invoked via `env`, and takes a filena
 
 #### Custom `#!` Support
 
-If you want a custom `#!` line in your script, you can use the `#!` executor.
+Run allows you to define custom `#!` lines in your command script:
 
 ##### C Example
 
@@ -773,7 +773,7 @@ _Runfile_
 ##
 # Hello world c example using #! executor.
 # NOTE: Requires gcc
-hello (#!):
+hello:
   #!/usr/bin/env sh
   sed -n -e '7,$p' < "$0" | gcc -x c -o "$0.$$.out" -
   $0.$$.out "$0" "$@"

--- a/internal/runfile/runfile.go
+++ b/internal/runfile/runfile.go
@@ -1,6 +1,10 @@
 package runfile
 
-import "github.com/tekwizely/run/internal/config"
+import (
+	"strings"
+
+	"github.com/tekwizely/run/internal/config"
+)
 
 // Runfile stores the processed file, ready to run.
 //
@@ -60,9 +64,19 @@ func (c *RunCmd) Title() string {
 func (c *RunCmd) Shell() string {
 	var shell string
 	if shell = c.Config.Shell; len(shell) == 0 {
-		var ok bool
-		if shell, ok = c.Scope.Attrs[".SHELL"]; !ok || len(shell) == 0 {
-			shell = config.DefaultShell
+		// Shebang?
+		//
+		if len(c.Script) > 0 && strings.HasPrefix(c.Script[0], "#!") {
+			shell = "#!"
+		} else {
+			// Global shell configured?
+			//
+			var ok bool
+			if shell, ok = c.Scope.Attrs[".SHELL"]; !ok || len(shell) == 0 {
+				// Use default
+				//
+				shell = config.DefaultShell
+			}
 		}
 	}
 	return shell


### PR DESCRIPTION
This change adds he ability to auto-detect `#!` scripts (as opposed to needing to explicitly specify `'#!'` as the shell)

Specifying `'#!'` explicitly still works, but has been removed from the documentation.

Fixes #10 