### PR TITLE
Makes .SHELL available for read

### DIFF
--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -13,6 +13,9 @@ import (
 //
 func ProcessAST(ast *Ast) *runfile.Runfile {
 	rf := runfile.NewRunfile()
+	// Seed defaults
+	//
+	rf.Scope.PutAttr(".SHELL", config.DefaultShell)
 	for _, n := range ast.nodes {
 		n.Apply(rf)
 	}


### PR DESCRIPTION
Adds .SHELL to available attributes before processing the parsed Runfile.

---

Fixes #16 