### PR TITLE
Renames version as run-version in shebang mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -847,15 +847,50 @@ _shebang mode list example_
 $ ./runfile.sh list
 
 Commands:
-  list       (builtin) List available commands
-  help       (builtin) Show Help for a command
-  version    (builtin) Show Run version
-  hello      Hello example using shebang mode
+  list           (builtin) List available commands
+  help           (builtin) Show Help for a command
+  run-version    (builtin) Show Run version
+  hello          Hello example using shebang mode
 Usage:
        runfile.sh help <command>
                  (show help for <command>)
   or   runfile.sh <command> [option ...]
                  (run <command>)
+```
+
+#### Version command name
+
+In shebang mode, the `version` command is renamed to `run-version`.  This enables you to create your own `version` command, while still providing access to run's version info, if needed.
+
+_runfile.sh_
+
+```
+#!/usr/bin/env run shebang
+
+## Show runfile.sh version
+version:
+    echo "runfile.sh v1.2.3"
+
+## Hello example using shebang mode
+hello:
+  echo "Hello, world"
+```
+
+_shebang mode version example_
+```
+$ ./runfile.sh list
+  ...
+  run-version    (builtin) Show Run version
+  version        Show runfile.sh version
+  ...
+
+$ ./runfile.sh version
+
+runfile.sh v1.2.3
+
+$ ./runfile.sh run-version
+
+run v0.0.0
 ```
 
 -------------

--- a/main.go
+++ b/main.go
@@ -140,6 +140,8 @@ func main() {
 		Run:    func() { runfile.ListCommands() },
 		Rename: func(_ string) {},
 	}
+	config.CommandMap["list"] = listCmd
+	config.CommandList = append(config.CommandList, listCmd)
 	helpCmd := &config.Command{
 		Name:   "help",
 		Title:  "(builtin) Show Help for a command",
@@ -147,17 +149,24 @@ func main() {
 		Run:    func() { runfile.RunHelp(rf) },
 		Rename: func(_ string) {},
 	}
+	config.CommandMap["help"] = helpCmd
+	config.CommandList = append(config.CommandList, helpCmd)
+	// In shebang mode, Version registered as 'run-version'
+	//
+	versionName := "version"
+	if config.ShebangMode {
+		versionName = "run-version"
+	}
+
 	versionCmd := &config.Command{
-		Name:   "version",
+		Name:   versionName,
 		Title:  "(builtin) Show Run version",
 		Help:   showVersion,
 		Run:    showVersion,
 		Rename: func(_ string) {},
 	}
-	config.CommandMap["list"] = listCmd
-	config.CommandMap["help"] = helpCmd
-	config.CommandMap["version"] = versionCmd
-	config.CommandList = append(config.CommandList, listCmd, helpCmd, versionCmd)
+	config.CommandMap[versionName] = versionCmd
+	config.CommandList = append(config.CommandList, versionCmd)
 	builtinCnt := len(config.CommandList)
 	for _, rfcmd := range rf.Cmds {
 		name := strings.ToLower(rfcmd.Name) // normalize


### PR DESCRIPTION
Instead of just hiding the `version` command in shebang mode, I decided to rename it.

In regular mode, the command will still be available as `version`:

```
$ run -r my-runfile version

run v0.0.0
```

But it shebang mode, the command I will be available under `run-version`:

```
$ ./my-runfile-app run-version

run v0.0.0
```

This leaves your Runfile free to define its own `version` command

__Runfile__
```
version:
    echo "my-runfile-app v1.2.3"
```
__output__
```
$ ./my-runfile-app version

my-runfile-app v1.2.3

$ ./my-runfile-app run-version

run v0.0.0
```

---

Fixes #18 