### PR TITLE
Adds .RUN and .RUNFILE attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ In run, the entire script is executed within a single sub-shell.
    - [Referencing Other Variables](#referencing-other-variables)
    - [Shell Substitution](#shell-substitution)
    - [Conditional Assignment](#conditional-assignment)
+   - [Invoking Other Commands & Runfiles](#invoking-other-commands--runfiles)
+     - [.RUN & .RUNFILE Attributes](#run--runfile-attributes)
  - [Script Shells](#script-shells)
    - [Per-Command Shell Config](#per-command-shell-config)
    - [Global Default Shell Config](#global-default-shell-config)
@@ -705,6 +707,37 @@ NAME="Newman" run hello
 
 Hello, Newman
 ```
+
+#### Invoking Other Commands & Runfiles
+
+##### .RUN / .RUNFILE Attributes
+Run exposes the following attributes:
+
+* `.RUN` - Absolute path of the run binary currently in use
+* `.RUNFILE` - Absolute path of the current Runfile
+
+Your command script can use these to invoke other commands:
+
+_Runfile_
+```
+##
+# Invokes hello
+# EXPORT RUN := ${.RUN}
+# EXPORT RUNFILE := ${.RUNFILE}
+test:
+    "${RUN}" -r "${RUNFILE}" hello
+
+hello:
+    echo "Hello, World"
+```
+
+_output_
+```
+$ run test
+
+Hello, World
+```
+
 
 -----------------
 ### Script Shells

--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -16,6 +16,8 @@ func ProcessAST(ast *Ast) *runfile.Runfile {
 	// Seed defaults
 	//
 	rf.Scope.PutAttr(".SHELL", config.DefaultShell)
+	rf.Scope.PutAttr(".RUN", config.RunBin)
+	rf.Scope.PutAttr(".RUNFILE", config.RunFile)
 	for _, n := range ast.nodes {
 		n.Apply(rf)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -50,6 +50,13 @@ var CommandList []*Command
 //
 var CommandMap = make(map[string]*Command)
 
+// RunBin holds the absolute path to the run command in use.
+//
+var RunBin string
+
+// RunFile holds the absolute path to the current Runfile.
+var RunFile string
+
 // EnableFnTrace shows parser/lexer fn call/stack
 //
 var EnableFnTrace = false


### PR DESCRIPTION

Adds `.RUN` and `.RUNFILE` attributes to make it possible to invoke other commands / runfiles from within your command script.

_Runfile_
```
##
# Invokes hello
# EXPORT RUN := ${.RUN}
# EXPORT RUNFILE := ${.RUNFILE}
test:
    "${RUN}" -r "${RUNFILE}" hello
hello:
    echo "Hello, World"
```

_output_
```
$ run test

Hello, World
```

---

Fixes #20 
