### PR TITLE
run: Plumb the exit code of a command back to run

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,7 +14,7 @@ type Command struct {
 	Name   string
 	Title  string
 	Help   func()
-	Run    func()
+	Run    func() int
 	Rename func(string) // Rename Command to script Name in 'main' mode
 }
 

--- a/internal/runfile/command.go
+++ b/internal/runfile/command.go
@@ -432,7 +432,7 @@ func RunHelp(_ *Runfile) {
 
 // RunCommand executes a command.
 //
-func RunCommand(cmd *RunCmd) {
+func RunCommand(cmd *RunCmd) int {
 	os.Args = evaluateCmdOpts(cmd, os.Args)
 	env := make(map[string]string)
 	for _, name := range cmd.Scope.GetExports() {
@@ -463,5 +463,5 @@ func RunCommand(cmd *RunCmd) {
 	// Execute script - Uses cmd shell
 	//
 	shell = cmd.Shell()
-	exec.ExecuteCmdScript(shell, cmd.Script, os.Args, env)
+	return exec.ExecuteCmdScript(shell, cmd.Script, os.Args, env)
 }


### PR DESCRIPTION
This allows failing a command if a run script fails, for example.