### PR TITLE
exec: Provide a way to cleanup the temporary dir

### DIFF
--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -110,3 +110,10 @@ func tempFile(pattern string) (*os.File, error) {
 	}
 	return ioutil.TempFile(tempDir, pattern)
 }
+
+func CleanupTemporaryDir() error {
+	if tempDir != "" {
+		return os.RemoveAll(tempDir)
+	}
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/tekwizely/run/internal/ast"
 	"github.com/tekwizely/run/internal/config"
+	"github.com/tekwizely/run/internal/exec"
 	"github.com/tekwizely/run/internal/lexer"
 	"github.com/tekwizely/run/internal/parser"
 	"github.com/tekwizely/run/internal/runfile"
@@ -77,6 +78,10 @@ func main() {
 	//       Actual errors in Run proper should invoke os.Exit directly
 	cmdExitCode := 0
 	defer func() {
+		err := exec.CleanupTemporaryDir()
+		if err != nil {
+			log.Printf("run: failed to clean up temporary dir: %s", err)
+		}
 		if cmdExitCode != 0 {
 			os.Exit(cmdExitCode)
 		}


### PR DESCRIPTION
ioutil.TempDir passes the responsibility of cleanup onto us. We weren't
doing this, which leads to a temp dir that is full of runfile- temp
entries.

Thus, introduce a way to cleanup after ourselves.
This isn't exactly a problem, as most modern distributions
automatically clear stale entries out of /tmp, but it looks rather messy.