### PR TITLE
WIP: Show a better error on duplicate command

### DIFF
--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -225,6 +225,7 @@ type Cmd struct {
 	Name   string
 	Config *CmdConfig
 	Script []string
+	Line   int
 }
 
 // Apply applies the node to the runfile.
@@ -234,6 +235,7 @@ func (a *Cmd) Apply(r *runfile.Runfile) {
 		Name:   a.Name,
 		Scope:  runfile.NewScope(),
 		Script: a.Script,
+		Line:   a.Line,
 	}
 	// Exports
 	//

--- a/internal/runfile/runfile.go
+++ b/internal/runfile/runfile.go
@@ -48,6 +48,7 @@ type RunCmd struct {
 	Config *RunCmdConfig
 	Scope  *Scope
 	Script []string
+	Line   int
 }
 
 // Title fetches the first line of the description as the command title.

--- a/main.go
+++ b/main.go
@@ -192,11 +192,18 @@ func main() {
 	config.CommandMap[versionName] = versionCmd
 	config.CommandList = append(config.CommandList, versionCmd)
 	builtinCnt := len(config.CommandList)
+	commandLocations := make(map[string]int)
+
 	for _, rfcmd := range rf.Cmds {
 		name := strings.ToLower(rfcmd.Name) // normalize
 		if _, ok := config.CommandMap[name]; ok {
-			panic("Duplicate command: " + name)
+			if prevline, ok := commandLocations[name]; ok {
+				panic(fmt.Sprintf("Duplicate command: %s defined on line %d -- originally defined on line %d", name, rfcmd.Line, prevline))
+			} else {
+				panic(fmt.Sprintf("Duplicate command: %s defined on line %d -- this command is built-in", name, rfcmd.Line))
+			}
 		}
+		commandLocations[name] = rfcmd.Line
 		cmd := &config.Command{
 			Name:   rfcmd.Name,
 			Title:  rfcmd.Title(),


### PR DESCRIPTION
Usecase:
```
foo:
    echo "hello"

foo:
    echo "world"
```
Gives: `run: Duplicate command: foo defined on line 4 -- originally defined on line 0`

```
version:
    echo "hello"
```
Gives: `run: Duplicate command: version defined on line 0 -- this command is built-in`

Marked as  WIP because the first line is showing up with line 0. I'm not sure if this is a bug in the parser/tokenizer, or if I'm missing something. It seems strange that the second definition is correctly showing up as line 4...