### PR TITLE
feat: Add support for overriding commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ In run, the entire script is executed within a single sub-shell.
      - [Cannot Re-Register Command In Same Runfile](#cannot-re-register-command-in-same-runfile)
      - [Overrides Are Case-Insensitive](#overrides-are-case-insensitive)
      - [First Registered Command Defines Case For Help](#first-registered-command-defines-case-for-help)
+     - [First Registered Command Defines Default Documentation](#first-registered-command-defines-default-documentation)
      - [Commands Are Listed In The Order They Are Registered](#commands-are-listed-in-the-order-they-are-registered)
  - [Invoking Other Commands & Runfiles](#invoking-other-commands--runfiles)
    - [.RUN & .RUNFILE Attributes](#run--runfile-attributes)
@@ -1009,7 +1010,6 @@ hello-world:
 ```
 
 _list commands_
-
 ```
 $ run list
 
@@ -1032,7 +1032,7 @@ include Runfile-include
 _Runfile-include_
 ```
 ## defined in Runfile-include
-Command1:
+COMMAND1:
   echo command1 from Runfile-include
 ```
 
@@ -1045,11 +1045,11 @@ Commands:
   command1    defined in Runfile-include
 ```
 
-Notice that `Command1` from the _included_ runfile overrides `command1` from the _primary_ runfile.
+Notice that `COMMAND1` from the _included_ runfile overrides `command1` from the _primary_ runfile.
 
 ###### First Registered Command Defines Case For Help
 
-Run keeps track of the original case used when a command is first registered, and uses _that_ name when displaying help:
+Run keeps track of the original case used when a command is first registered, and uses it when displaying help:
 
 _Runfile_
 ```
@@ -1074,10 +1074,46 @@ $ run list
 Commands:
   ...
   COMMAND1    defined in Runfile-include
-
 ```
 
-Notice that, even though `command1` from the _included_ runfile will be invoked, the displayed name comes from the original registration in the _primary_ runfile.
+Notice that the displayed name comes from the original registration in the _primary_ runfile.
+
+##### First Registered Command Defines Default Documentation
+
+Run keeps track of the title & description when a command is first registered, and uses it if an overriding command does not define its own documentation:
+
+_Runfile_
+```
+## title defined in Runfile
+command1:
+  echo command1 from Runfile
+
+include Runfile-include
+```
+
+_Runfile-include_
+```
+command1:
+  echo command1 from Runfile-include
+```
+
+_list commands_
+```
+$ run list
+
+Commands:
+  ...
+  commmand1    title defined in Runfile
+```
+
+_command output_
+```
+$ run command1
+
+command1 from Runfile-include
+```
+
+Notice that, even though `command1` from the _included_ runfile was invoked, the displayed title comes from the original registration in the _primary_ runfile.
 
 ##### Commands Are Listed In The Order They Are Registered
 
@@ -1107,7 +1143,7 @@ command2:
   echo command2 from Runfile-include
 ```
 
-_usage_
+_list commands_
 ```
 $ run list
 

--- a/README.md
+++ b/README.md
@@ -166,8 +166,8 @@ _Runfile_
 hello-world:
   echo "Hello, world"
 
-Hello-World:
-  echo "Hello, world"
+HELLO-WORLD:
+  echo "HELLO, WORLD"
 ```
 
 _list commands_

--- a/README.md
+++ b/README.md
@@ -81,6 +81,11 @@ In run, the entire script is executed within a single sub-shell.
    - [Working Directory](#working-directory)
    - [File(s) Not Found](#files-not-found)
    - [Avoiding Include Loops](#avoiding-include-loops)
+   - [Overriding Commands](#overriding-commands)
+     - [Cannot Re-Register Command In Same Runfile](#cannot-re-register-command-in-same-runfile)
+     - [Overrides Are Case-Insensitive](#overrides-are-case-insensitive)
+     - [First Registered Command Defines Case For Help](#first-registered-command-defines-case-for-help)
+     - [Commands Are Listed In The Order They Are Registered](#commands-are-listed-in-the-order-they-are-registered)
  - [Invoking Other Commands & Runfiles](#invoking-other-commands--runfiles)
    - [.RUN & .RUNFILE Attributes](#run--runfile-attributes)
  - [Script Shells](#script-shells)
@@ -148,6 +153,31 @@ Some examples:
 
 ##### Case Sensitivity
 
+###### Registering Commands
+
+When registering commands, run treats the command name as case-insensitive and subject to [command override](#overriding-commands) rules.
+
+*case-insensitive override example*
+
+For example, run will generate an error if a command name is defined multiple times in the same runfile, even if the names use different cases:
+
+_Runfile_
+```
+hello-world:
+  echo "Hello, world"
+
+Hello-World:
+  echo "Hello, world"
+```
+
+_list commands_
+
+```
+$ run list
+
+run: Runfile: command hello-world defined multiple times in the same file: lines 1 and 4
+```
+
 ###### Invoking Commands
 
 When invoking commands, run treats the command name as case-insensitive:
@@ -169,7 +199,7 @@ Hello, world
 
 ###### Displaying Help
 
-When displaying help text, run treats the command name as case-sensitive, displaying the command name as it is defined:
+When displaying help text, run displays command names as they are originally defined:
 
 _list commands_
 
@@ -177,37 +207,16 @@ _list commands_
 $ run list
 
 Commands:
-  ..
+  ...
   Hello-World
   ...
 ```
 
 _show help for Hello-World command_
 ```
-$ run help Hello-World
+$ run help hello-world
 
 Hello-World: no help available.
-```
-
-###### Duplicate Command Names
-
-When registering commands, run treats the command name as case-insensitive, generating an error if a command name is defined multiple times:
-
-_Runfile_
-```
-hello-world:
-  echo "Hello, world"
-
-Hello-World:
-  echo "Hello, world"
-```
-
-_list commands_
-
-```
-$ run list
-
-run: duplicate command: hello-world defined on line 4 -- originally defined on line 1
 ```
 
 ----------------------------
@@ -945,6 +954,171 @@ _Runfile_
 INCLUDE Runfile-hello
 INCLUDE Runfile-hello  # Silently skipped
 ```
+
+#### Overriding Commands
+
+Run allows you override commands, as long as they were originally registered in a _different_ Runfile.
+
+_Runfile_
+```
+## defined in Runfile
+command1:
+  echo command1 from Runfile
+
+INCLUDE Runfile-include
+
+## defined in Runfile
+command2:
+  echo command2 from Runfile
+```
+
+_Runfile-include_
+```
+## defined in Runfile-include
+command1:
+  echo command1 from Runfile-include
+
+## defined in Runfile-include
+command2:
+  echo command2 from Runfile-include
+```
+
+_list commands_
+```
+$ run list
+
+Commands:
+  ...
+  command1    defined in Runfile-include
+  command2    defined in Runfile
+```
+
+Notice that the _included_ runfile overrides `command1`, but the _primary_ runfile overrides `command2`.
+
+##### Cannot Re-Register Command In Same Runfile
+
+Run will error when attempting to register a command multiple times within the _same_ Runfile:
+
+_Runfile_
+```
+hello-world:
+  echo "Hello, world"
+
+hello-world:
+  echo "Hello, world"
+```
+
+_list commands_
+
+```
+$ run list
+
+run: Runfile: command hello-world defined multiple times in the same file: lines 1 and 4
+```
+
+##### Overrides Are Case-Insensitive
+
+Run's override matching is case-insensitive:
+
+_Runfile_
+```
+## defined in Runfile
+command1:
+  echo command1 from Runfile
+
+include Runfile-include
+```
+
+_Runfile-include_
+```
+## defined in Runfile-include
+Command1:
+  echo command1 from Runfile-include
+```
+
+_list commands_
+```
+$ run list
+
+Commands:
+  ...
+  command1    defined in Runfile-include
+```
+
+Notice that `Command1` from the _included_ runfile overrides `command1` from the _primary_ runfile.
+
+###### First Registered Command Defines Case For Help
+
+Run keeps track of the original case used when a command is first registered, and uses _that_ name when displaying help:
+
+_Runfile_
+```
+## defined in Runfile
+COMMAND1:
+  echo command1 from Runfile
+
+include Runfile-include
+```
+
+_Runfile-include_
+```
+## defined in Runfile-include
+command1:
+  echo command1 from Runfile-include
+```
+
+_list commands_
+```
+$ run list
+
+Commands:
+  ...
+  COMMAND1    defined in Runfile-include
+
+```
+
+Notice that, even though `command1` from the _included_ runfile will be invoked, the displayed name comes from the original registration in the _primary_ runfile.
+
+##### Commands Are Listed In The Order They Are Registered
+
+Run keeps track of the _order_ in which commands are registered, and maintains that order even if a command is later overridden:
+
+_Runfile_
+```
+## defined in Runfile
+command1:
+  echo command1 from Runfile
+
+## defined in Runfile
+command2:
+  echo command2 from Runfile
+
+## defined in Runfile
+command3:
+  echo command3 from Runfile
+
+include Runfile-include
+```
+
+_Runfile-include_
+```
+## defined in Runfile-include
+command2:
+  echo command2 from Runfile-include
+```
+
+_usage_
+```
+$ run list
+
+Commands:
+  ...
+  command1    defined in Runfile
+  command2    defined in Runfile-include
+  command3    defined in Runfile
+```
+
+Notice that `command2` is still shown _between_ `command1` and `command3`, matching the order in which it was originally registered.
 
 --------------------------------------
 ### Invoking Other Commands & Runfiles

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,11 +11,12 @@ import (
 // Command is an abstraction for a command, allowing us to mix runfile commands and custom comments (help, list, etc).
 //
 type Command struct {
-	Name   string
-	Title  string
-	Help   func()
-	Run    func() int
-	Rename func(string) // Rename Command to script Name in 'main' mode
+	Name    string
+	Title   string
+	Help    func()
+	Run     func() int
+	Rename  func(string) // Rename Command to script Name in 'main' mode
+	Builtin bool
 }
 
 // DefaultShell specifies which shell to use for command scripts and sub-shells if none explicitly defined.
@@ -85,6 +86,11 @@ var ShowScriptTmpDir = false
 // ShowCmdShells shows the command shell in the command's help screen
 //
 var ShowCmdShells = false
+
+// ShowNotices shows NOTICE level logging
+// TODO Support verbose mode, so we can display notices :)
+//
+var ShowNotices = true
 
 // EnableRunfileOverride indicates if $RUNFILE env var or '-r | --runfile' arguments are supported in the current mode.
 //

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -90,7 +90,7 @@ var ShowCmdShells = false
 // ShowNotices shows NOTICE level logging
 // TODO Support verbose mode, so we can display notices :)
 //
-var ShowNotices = true
+var ShowNotices = false
 
 // EnableRunfileOverride indicates if $RUNFILE env var or '-r | --runfile' arguments are supported in the current mode.
 //

--- a/internal/runfile/runfile.go
+++ b/internal/runfile/runfile.go
@@ -44,11 +44,12 @@ type RunCmdConfig struct {
 // RunCmd captures a command.
 //
 type RunCmd struct {
-	Name   string
-	Config *RunCmdConfig
-	Scope  *Scope
-	Script []string
-	Line   int
+	Name    string
+	Config  *RunCmdConfig
+	Scope   *Scope
+	Script  []string
+	Runfile string
+	Line    int
 }
 
 // Title fetches the first line of the description as the command title.

--- a/main.go
+++ b/main.go
@@ -210,20 +210,22 @@ func main() {
 	// Setup Commands
 	//
 	listCmd := &config.Command{
-		Name:   "list",
-		Title:  "(builtin) List available commands",
-		Help:   func() { runfile.ListCommands() },
-		Run:    func() int { runfile.ListCommands(); return 0 },
-		Rename: func(_ string) {},
+		Name:    "list",
+		Title:   "(builtin) List available commands",
+		Help:    func() { runfile.ListCommands() },
+		Run:     func() int { runfile.ListCommands(); return 0 },
+		Rename:  func(_ string) {},
+		Builtin: true,
 	}
 	config.CommandMap[listCmd.Name] = listCmd
 	config.CommandList = append(config.CommandList, listCmd)
 	helpCmd := &config.Command{
-		Name:   "help",
-		Title:  "(builtin) Show help for a command",
-		Help:   showRunHelp,
-		Run:    runfile.RunHelp,
-		Rename: func(_ string) {},
+		Name:    "help",
+		Title:   "(builtin) Show help for a command",
+		Help:    showRunHelp,
+		Run:     runfile.RunHelp,
+		Rename:  func(_ string) {},
+		Builtin: true,
 	}
 	config.CommandMap[helpCmd.Name] = helpCmd
 	config.CommandList = append(config.CommandList, helpCmd)
@@ -234,11 +236,12 @@ func main() {
 		versionName = "run-version"
 	}
 	versionCmd := &config.Command{
-		Name:   versionName,
-		Title:  "(builtin) Show run version",
-		Help:   func() { showVersion() },
-		Run:    func() int { showVersion(); return 0 },
-		Rename: func(_ string) {},
+		Name:    versionName,
+		Title:   "(builtin) Show run version",
+		Help:    func() { showVersion() },
+		Run:     func() int { showVersion(); return 0 },
+		Rename:  func(_ string) {},
+		Builtin: true,
 	}
 	config.CommandMap[versionName] = versionCmd
 	config.CommandList = append(config.CommandList, versionCmd)
@@ -247,30 +250,72 @@ func main() {
 	// Register runfile commands, if loaded
 	//
 	if rf != nil {
-		commandLines := make(map[string]int)
-		for _, rfCmd := range rf.Cmds {
-			name := strings.ToLower(rfCmd.Name) // normalize
+		runCommandsByFileAndName := make(map[string]map[string]*runfile.RunCmd)
+		runCommandsByName := make(map[string]*runfile.RunCmd)
+		for _, newRunCommand := range rf.Cmds {
+			newRunCommandName := newRunCommand.Name     // Un-normalized name used for help
+			name := strings.ToLower(newRunCommand.Name) // normalize
 			// Look for dupes
 			//
-			if _, ok := config.CommandMap[name]; ok {
-				if commandLine, ok := commandLines[name]; ok {
-					panic(fmt.Sprintf("duplicate command: %s defined on line %d -- originally defined on line %d", name, rfCmd.Line, commandLine))
-				} else {
-					panic(fmt.Sprintf("duplicate command: %s defined on line %d -- this command is built-in", name, rfCmd.Line))
+			configIndex := -1 // Keep original CommandList index when overriding commands; Makes help lists consistent
+			if existingConfigCommand, ok := config.CommandMap[name]; ok {
+				// Can't override builtin commands
+				//
+				if existingConfigCommand.Builtin {
+					panic(fmt.Sprintf("%s:%d cannot override built-in command %s", newRunCommand.Runfile, newRunCommand.Line, name))
 				}
+				// Can't override commands defined in same runfile
+				//
+				if runCommandsByNameForFile, ok := runCommandsByFileAndName[newRunCommand.Runfile]; ok {
+					if oldRunCommandForFile, ok := runCommandsByNameForFile[name]; ok {
+						panic(fmt.Sprintf("%s: command %s defined multiple times in the same file: lines %d and %d", newRunCommand.Runfile, name, oldRunCommandForFile.Line, newRunCommand.Line))
+					}
+				}
+				// OK to override command, but notify user
+				//
+				if config.ShowNotices {
+					if oldRunCommand, ok := runCommandsByName[name]; ok { // Should ALWAYS succeed
+						log.Printf("NOTICE: %s:%d command %s overrides command %s defined in %s:%d", newRunCommand.Runfile, newRunCommand.Line, newRunCommand.Name, oldRunCommand.Name, oldRunCommand.Runfile, oldRunCommand.Line)
+					}
+				}
+				// Remove old command, taking note of command name and CommandList index, which will be re-used
+				//
+				delete(config.CommandMap, name) // Technically not needed but feels cleaner
+				for i := range config.CommandList {
+					if config.CommandList[i] == existingConfigCommand {
+						configIndex = i
+						break
+					}
+				}
+				// For help display, first registered command wins - So propagate existing name
+				//
+				newRunCommandName = existingConfigCommand.Name
 			}
 			// Register cmd
 			//
-			commandLines[name] = rfCmd.Line
+			fileCommandsByName, ok := runCommandsByFileAndName[newRunCommand.Runfile]
+			if !ok {
+				fileCommandsByName = make(map[string]*runfile.RunCmd)
+				runCommandsByFileAndName[newRunCommand.Runfile] = fileCommandsByName
+			}
+			fileCommandsByName[name] = newRunCommand
+			runCommandsByName[name] = newRunCommand
 			cmd := &config.Command{
-				Name:   rfCmd.Name,
-				Title:  rfCmd.Title(),
-				Help:   func(c *runfile.RunCmd) func() { return func() { runfile.ShowCmdHelp(c) } }(rfCmd),
-				Run:    func(c *runfile.RunCmd) func() int { return func() int { return runfile.RunCommand(c) } }(rfCmd),
-				Rename: func(c *runfile.RunCmd) func(string) { return func(s string) { c.Name = s } }(rfCmd),
+				Name:    newRunCommandName,
+				Title:   newRunCommand.Title(),
+				Help:    func(c *runfile.RunCmd) func() { return func() { runfile.ShowCmdHelp(c) } }(newRunCommand),
+				Run:     func(c *runfile.RunCmd) func() int { return func() int { return runfile.RunCommand(c) } }(newRunCommand),
+				Rename:  func(c *runfile.RunCmd) func(string) { return func(s string) { c.Name = s } }(newRunCommand),
+				Builtin: false,
 			}
 			config.CommandMap[name] = cmd
-			config.CommandList = append(config.CommandList, cmd)
+			// Append or replace?
+			//
+			if configIndex >= 0 {
+				config.CommandList[configIndex] = cmd
+			} else {
+				config.CommandList = append(config.CommandList, cmd)
+			}
 		}
 	}
 	// In shebang mode, if only 1 runfile command defined, named "main", default to it directly


### PR DESCRIPTION
- Allows overriding commands as long as they are defined in *different* Runfiles
  - Still can't define a command multiple times in *same* Runfile
- Command's list position based on first occurrence
- Command's display name based on first occurrence

bug: Display Runfile in post-parsing error reporting
chore: Capture Runfile in ast.Cmd and runfile.RunCmd
chore: Add builtin flag to config.Command

--- 

cc: @MadBomber Care to give this a test drive / once-over ? 