### PR TITLE
feat: Easily export attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ In run, the entire script is executed within a single sub-shell.
    - [`.RUNFILE.DIR`](#runfile-attributes)
    - [`.SELF`](#runfile-attributes)
    - [`.SELF.DIR`](#runfile-attributes)
+   - [Exporting Attributes](#exporting-attributes)
+     - [Simple Export](#simple-export)
+     - [Export With Name](#export-with-name)
  - [Assertions](#assertions)
  - [Includes](#includes)
    - [File Globbing](#file-globbing)
@@ -786,6 +789,67 @@ Following is the list of Run's attributes:
 | `.RUNFILE.DIR` | Contains the absolute path of the parent folder of the **primary** runfile.
 | `.SELF`        | Contains the absolute path of the **current** (primary or included) runfile.
 | `.SELF.DIR`    | Contains the absolute path of the parent folder of the **current** runfile.
+
+
+#### Exporting Attributes
+
+In order to access an attribute's value within your commands, you'll need to assign them to an [exported variable](#exporting-variables).
+
+Older versions of Run required you to use a variable assignment:
+
+_Runfile_
+```
+EXPORT RUNFILE     := ${.RUNFILE}
+EXPORT RUNFILE_DIR := ${.RUNFILE.DIR}
+
+## Prints the value of .RUNFILE
+runfile:
+    echo "${RUNFILE}"
+
+## Prints the value of .RUNFILE.DIR
+runfile-dir:
+    echo "${RUNFILE_DIR}"
+```
+
+Newer versions of Run now support less verbose options:
+
+##### Simple Export
+
+You can quickly export an attribute with a default variable name:
+
+_Runfile_
+```
+EXPORT .RUNFILE, .RUNFILE.DIR
+
+## Prints the value of .RUNFILE
+runfile:
+    echo "${RUNFILE}"
+
+## Prints the value of .RUNFILE.DIR
+runfile-dir:
+    echo "${RUNFILE_DIR}"
+```
+
+With this technique, Run uses the attribute's name to determine the exported variable's name by:
+* Removing the leading `.` character
+* Substituting any remaining `.` characters with `_`
+
+##### Export With Name
+
+If you want to export an attribute with a non-default variable name, you can use the `AS` syntax:
+
+```
+EXPORT .RUNFILE     AS RF
+EXPORT .RUNFILE.DIR AS RFD
+
+## Prints the value of .RUNFILE
+runfile:
+    echo "${RF}"
+
+## Prints the value of .RUNFILE.DIR
+runfile-dir:
+    echo "${RFD}"
+```
 
 --------------
 ### Assertions

--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -409,7 +409,7 @@ func (a *Cmd) Apply(r *runfile.Runfile) {
 		cmd.Scope.ExportVar(export.VarName)
 	}
 	for _, export := range r.Scope.GetAttrExports() {
-		cmd.Scope.ExportAttr(export.VarName, export.AttrName)
+		cmd.Scope.ExportAttr(export.AttrName, export.VarName)
 	}
 	for _, export := range a.Config.VarExports {
 		cmd.Scope.ExportVar(export.VarName)

--- a/internal/lexer/tokens.go
+++ b/internal/lexer/tokens.go
@@ -49,6 +49,7 @@ const (
 	TokenDBracketStringEnd   // ' ]]'
 
 	TokenExport
+	TokenAs
 	TokenAssert
 	TokenInclude
 	TokenCommand

--- a/internal/runfile/command.go
+++ b/internal/runfile/command.go
@@ -268,11 +268,11 @@ func evaluateCmdOpts(cmd *RunCmd, args []string) ([]string, int) {
 	// TODO Maybe make args property instead of stashing in vars?
 	for name, value := range stringValues {
 		cmd.Scope.Vars[name] = value.String()
-		cmd.Scope.AddExport(name)
+		cmd.Scope.ExportVar(name)
 	}
 	for name, value := range boolValues {
 		cmd.Scope.Vars[name] = value.String()
-		cmd.Scope.AddExport(name)
+		cmd.Scope.ExportVar(name)
 	}
 	return flags.Args(), 0
 }
@@ -443,11 +443,18 @@ func RunCommand(cmd *RunCmd) int {
 		return exitCode
 	}
 	env := make(map[string]string)
-	for _, name := range cmd.Scope.GetExports() {
-		if value, ok := cmd.Scope.GetVar(name); ok {
-			env[name] = value
+	for _, export := range cmd.Scope.GetVarExports() {
+		if value, ok := cmd.Scope.GetVar(export.VarName); ok {
+			env[export.VarName] = value
 		} else {
-			log.Printf("WARNING: exported variable not defined: '%s'", name)
+			log.Printf("WARNING: exported variable not defined: '%s'", export.VarName)
+		}
+	}
+	for _, export := range cmd.Scope.GetAttrExports() {
+		if value, ok := cmd.Scope.GetAttr(export.AttrName); ok {
+			env[export.VarName] = value
+		} else {
+			log.Printf("WARNING: exported attribute not defined: '%s'", export.AttrName)
 		}
 	}
 	// Check Asserts - Uses global .SHELL

--- a/internal/runfile/scope.go
+++ b/internal/runfile/scope.go
@@ -11,23 +11,38 @@ type Assert struct {
 	Message string
 }
 
+// VarExport captures a variable export.
+//
+type VarExport struct {
+	VarName string
+}
+
+// AttrExport captures an attribute export.
+//
+type AttrExport struct {
+	AttrName string
+	VarName  string
+}
+
 // Scope isolates attrs, vars and exports
 //
 type Scope struct {
-	Attrs   map[string]string // All keys uppercase. Keys include leading '.'
-	Vars    map[string]string // Variables
-	Exports []string          // Exported variables
-	Asserts []*Assert         // Assertions
+	Attrs       map[string]string // All keys uppercase. Keys include leading '.'
+	Vars        map[string]string // Variables
+	VarExports  []*VarExport      // Exported variables
+	AttrExports []*AttrExport     // Exported attributes
+	Asserts     []*Assert         // Assertions
 }
 
 // NewScope is a convenience method
 //
 func NewScope() *Scope {
 	return &Scope{
-		Attrs:   map[string]string{},
-		Vars:    map[string]string{},
-		Exports: []string{},
-		Asserts: []*Assert{},
+		Attrs:       map[string]string{},
+		Vars:        map[string]string{},
+		VarExports:  []*VarExport{},
+		AttrExports: []*AttrExport{},
+		Asserts:     []*Assert{},
 	}
 }
 
@@ -50,29 +65,41 @@ func (s *Scope) PutAttr(key, value string) {
 	s.Attrs[key] = value
 }
 
-// GetVar fetches a var
+// ExportAttr adds an attribute name to the list of exports
+//
+func (s *Scope) ExportAttr(attrName string, varName string) {
+	s.AttrExports = append(s.AttrExports, &AttrExport{AttrName: attrName, VarName: varName})
+}
+
+// GetAttrExports fetches the full list of attribute exports
+//
+func (s *Scope) GetAttrExports() []*AttrExport {
+	return s.AttrExports
+}
+
+// GetVar fetches a variable
 //
 func (s *Scope) GetVar(key string) (string, bool) {
 	val, ok := s.Vars[key]
 	return val, ok
 }
 
-// PutVar sets a var
+// PutVar sets a variable
 //
 func (s *Scope) PutVar(key, value string) {
 	s.Vars[key] = value
 }
 
-// AddExport adds a var name to the list of exports
+// ExportVar adds a variable name to the list of exports
 //
-func (s *Scope) AddExport(key string) {
-	s.Exports = append(s.Exports, key)
+func (s *Scope) ExportVar(name string) {
+	s.VarExports = append(s.VarExports, &VarExport{VarName: name})
 }
 
-// GetExports fetches the full list of exports
+// GetVarExports fetches the full list of variable exports
 //
-func (s *Scope) GetExports() []string {
-	return s.Exports
+func (s *Scope) GetVarExports() []*VarExport {
+	return s.VarExports
 }
 
 // AddAssert adds an assertion to the list of asserts


### PR DESCRIPTION
Enables two quick ways to export an attribute:

Export with implied variable name based on attribute name
- EXPORT .ATTRIBUTE.NAME
  - Implicitly assigns to variable ATTRIBUTE_NAME, ie
  - Removes leading '.'
  - Replaces remaining '.' characters with '_'

Export with explicit variable name
- EXPORT .ATTRIBUTE.NAME AS VAR_NAME
  - Assigns to variable VAR_NAME

bug: Normalize attribute names in RHS references

TODO:
- [x] Update Readme

---

Fixes #57 