### PR TITLE
feat: Allow commands to RUN other commands

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,7 +14,7 @@ type Command struct {
 	Name    string
 	Title   string
 	Help    func()
-	Run     func() int
+	Run     func([]string, map[string]string) int
 	Rename  func(string) // Rename Command to script Name in 'main' mode
 	Builtin bool
 }

--- a/internal/lexer/runes.go
+++ b/internal/lexer/runes.go
@@ -63,12 +63,15 @@ func isMainToken(s string) bool {
 // Cmd Config Tokens
 //
 var cmdConfigTokens = map[string]token.Type{
-	"SHELL":  TokenConfigShell,
-	"USAGE":  TokenConfigUsage,
-	"OPTION": TokenConfigOpt,
-	"OPT":    TokenConfigOpt,
-	"EXPORT": TokenConfigExport,
-	"ASSERT": TokenConfigAssert,
+	"SHELL":      TokenConfigShell,
+	"USAGE":      TokenConfigUsage,
+	"OPTION":     TokenConfigOpt,
+	"OPT":        TokenConfigOpt,
+	"EXPORT":     TokenConfigExport,
+	"ASSERT":     TokenConfigAssert,
+	"RUN":        TokenConfigRunBefore,
+	"RUN.BEFORE": TokenConfigRunBefore,
+	"RUN.AFTER":  TokenConfigRunAfter,
 }
 
 func isAlpha(r rune) bool {

--- a/internal/lexer/tokens.go
+++ b/internal/lexer/tokens.go
@@ -9,6 +9,8 @@ import (
 const (
 	TokenNewline = lexer.TStart + iota
 
+	TokenNotNewline // Meta token
+
 	TokenID
 	TokenDotID
 	TokenDashID
@@ -68,6 +70,8 @@ const (
 	TokenConfigOptExample
 	TokenConfigExport
 	TokenConfigAssert
+	TokenConfigRunBefore
+	TokenConfigRunAfter
 
 	TokenConfigEnd
 

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -435,6 +435,29 @@ func tryMatchDocBlock(ctx *parseContext, p *parser.Parser) (*ast.CmdConfig, bool
 				cmdConfig.Asserts = append(cmdConfig.Asserts, assert)
 				expectTokenType(p, lexer.TokenNewline, "expecting end of line")
 				p.Clear()
+			case lexer.TokenConfigRunBefore, lexer.TokenConfigRunAfter:
+				t = p.Next()
+				ctx.pushLexFn(ctx.l.Fn)
+				ctx.setLexFn(lexer.LexExpectCommandName)
+				command := p.Next().Value()
+				var args []ast.ScopeValueNode
+				for {
+					ctx.setLexFn(lexer.LexMaybeNewline)
+					if tryPeekType(p, lexer.TokenNotNewline) {
+						p.Next()
+						args = append(args, expectAssignmentValue(ctx, p))
+					} else {
+						break
+					}
+				}
+				cmdRun := &ast.CmdRun{Command: command, Args: args}
+				if t.Type() == lexer.TokenConfigRunBefore {
+					cmdConfig.BeforeRuns = append(cmdConfig.BeforeRuns, cmdRun)
+				} else {
+					cmdConfig.AfterRuns = append(cmdConfig.AfterRuns, cmdRun)
+				}
+				expectTokenType(p, lexer.TokenNewline, "expecting end of line")
+				p.Clear()
 			default:
 				panic(fmt.Sprintf("%d:%d: Expecting cmd config statement", t.Line(), t.Column()))
 			}

--- a/internal/runfile/command.go
+++ b/internal/runfile/command.go
@@ -506,6 +506,10 @@ func RunCommand(cmdProvider CmdProvider, rf *Runfile, args []string, env map[str
 			log.Printf("ERROR: %s:%d: command not found: %s", cmd.Runfile, cmd.Line, cmdName)
 			return 2
 		}
+		if cmdMapEntry.Builtin {
+			log.Printf("ERROR: %s:%d: cannot RUN builtin command: %s", cmd.Runfile, cmd.Line, cmdName)
+			return 2
+		}
 		exitCode = cmdMapEntry.Run(runCmd.Args, cmdEnv)
 		if exitCode != 0 {
 			return exitCode
@@ -526,6 +530,10 @@ func RunCommand(cmdProvider CmdProvider, rf *Runfile, args []string, env map[str
 		var cmdExists bool
 		if cmdMapEntry, cmdExists = config.CommandMap[cmdName]; !cmdExists {
 			log.Printf("ERROR: %s:%d: command not found: %s", cmd.Runfile, cmd.Line, cmdName)
+			return 2
+		}
+		if cmdMapEntry.Builtin {
+			log.Printf("ERROR: %s:%d: cannot RUN builtin command: %s", cmd.Runfile, cmd.Line, cmdName)
 			return 2
 		}
 		exitCode = cmdMapEntry.Run(runCmd.Args, cmdEnv)

--- a/internal/runfile/command.go
+++ b/internal/runfile/command.go
@@ -445,23 +445,34 @@ func RunHelp() int {
 
 // RunCommand executes a command returning an exit code
 //
-func RunCommand(cmd *RunCmd) int {
+func RunCommand(cmdProvider CmdProvider, rf *Runfile, args []string, env map[string]string) int {
+	cmd := cmdProvider.GetCmdEnv(rf, env)
 	exitCode := 0
-	os.Args, exitCode = evaluateCmdOpts(cmd, os.Args)
+	args, exitCode = evaluateCmdOpts(cmd, args)
 	if exitCode != 0 {
 		return exitCode
 	}
-	env := make(map[string]string)
+	cmdEnv := make(map[string]string)
+	// Original env keys are assumed to be exported,
+	// but their values may have changed, so we re-fetch them
+	//
+	for varName := range env {
+		if value, ok := cmd.Scope.GetVar(varName); ok {
+			cmdEnv[varName] = value
+		} else {
+			log.Printf("WARNING: exported variable not defined: '%s'", varName)
+		}
+	}
 	for _, export := range cmd.Scope.GetVarExports() {
 		if value, ok := cmd.Scope.GetVar(export.VarName); ok {
-			env[export.VarName] = value
+			cmdEnv[export.VarName] = value
 		} else {
 			log.Printf("WARNING: exported variable not defined: '%s'", export.VarName)
 		}
 	}
 	for _, export := range cmd.Scope.GetAttrExports() {
 		if value, ok := cmd.Scope.GetAttr(export.AttrName); ok {
-			env[export.VarName] = value
+			cmdEnv[export.VarName] = value
 		} else {
 			log.Printf("WARNING: exported attribute not defined: '%s'", export.AttrName)
 		}
@@ -473,7 +484,7 @@ func RunCommand(cmd *RunCmd) int {
 		shell = config.DefaultShell
 	}
 	for _, assert := range cmd.Scope.Asserts {
-		if exec.ExecuteTest(shell, assert.Test, env) != 0 {
+		if exec.ExecuteTest(shell, assert.Test, cmdEnv) != 0 {
 			// Print message if one configured
 			//
 			if len(assert.Message) > 0 {
@@ -485,8 +496,42 @@ func RunCommand(cmd *RunCmd) int {
 			return 1
 		}
 	}
+	// Run 'Before' Commands
+	//
+	for _, runCmd := range cmd.Config.BeforeRuns {
+		cmdName := strings.ToLower(runCmd.Command) // Normalize
+		var cmdMapEntry *config.Command
+		var cmdExists bool
+		if cmdMapEntry, cmdExists = config.CommandMap[cmdName]; !cmdExists {
+			log.Printf("ERROR: %s:%d: command not found: %s", cmd.Runfile, cmd.Line, cmdName)
+			return 2
+		}
+		exitCode = cmdMapEntry.Run(runCmd.Args, cmdEnv)
+		if exitCode != 0 {
+			return exitCode
+		}
+	}
 	// Execute script - Uses cmd shell
 	//
 	shell = cmd.Shell()
-	return exec.ExecuteCmdScript(shell, cmd.Script, os.Args, env)
+	exitCode = exec.ExecuteCmdScript(shell, cmd.Script, args, cmdEnv)
+	if exitCode != 0 {
+		return exitCode
+	}
+	// Run 'After' Commands
+	//
+	for _, runCmd := range cmd.Config.AfterRuns {
+		cmdName := strings.ToLower(runCmd.Command) // Normalize
+		var cmdMapEntry *config.Command
+		var cmdExists bool
+		if cmdMapEntry, cmdExists = config.CommandMap[cmdName]; !cmdExists {
+			log.Printf("ERROR: %s:%d: command not found: %s", cmd.Runfile, cmd.Line, cmdName)
+			return 2
+		}
+		exitCode = cmdMapEntry.Run(runCmd.Args, cmdEnv)
+		if exitCode != 0 {
+			return exitCode
+		}
+	}
+	return exitCode
 }

--- a/internal/runfile/runfile.go
+++ b/internal/runfile/runfile.go
@@ -6,11 +6,18 @@ import (
 	"github.com/tekwizely/run/internal/config"
 )
 
+// CmdProvider allows us to construct commands
+// multiple times in different contexts.
+type CmdProvider interface {
+	GetCmd(r *Runfile) *RunCmd
+	GetCmdEnv(r *Runfile, env map[string]string) *RunCmd
+}
+
 // Runfile stores the processed file, ready to run.
 //
 type Runfile struct {
 	Scope *Scope
-	Cmds  []*RunCmd
+	Cmds  []CmdProvider
 }
 
 // NewRunfile is a convenience method.
@@ -18,11 +25,11 @@ type Runfile struct {
 func NewRunfile() *Runfile {
 	return &Runfile{
 		Scope: NewScope(),
-		Cmds:  []*RunCmd{},
+		Cmds:  []CmdProvider{},
 	}
 }
 
-// RunCmdOpt captures an OPTION
+// RunCmdOpt captures an OPTION.
 //
 type RunCmdOpt struct {
 	Name       string
@@ -35,13 +42,23 @@ type RunCmdOpt struct {
 	Desc       string
 }
 
+// RunCmdRun captures a command config RUN invocation.
+// TODO Better name?
+//
+type RunCmdRun struct {
+	Command string
+	Args    []string
+}
+
 // RunCmdConfig captures the configuration for a command.
 //
 type RunCmdConfig struct {
-	Shell  string
-	Desc   []string
-	Usages []string
-	Opts   []*RunCmdOpt
+	Shell      string
+	Desc       []string
+	Usages     []string
+	Opts       []*RunCmdOpt
+	BeforeRuns []*RunCmdRun
+	AfterRuns  []*RunCmdRun
 }
 
 // RunCmd captures a command.

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // DefaultIfEmpty returns default string of src string is empty.
@@ -78,4 +79,14 @@ func ReadFileIfExists(path string) ([]byte, bool, error) {
 	// If we get here, we have an error
 	//
 	return nil, false, err
+}
+
+// TryMakeRelative tries to generate a path for targetPath that is relative to basePath.
+// It returns either a path relative to basePath, if possible, or targetPath.
+//
+func TryMakeRelative(basePath string, targetPath string) string {
+	if rel, err := filepath.Rel(basePath, targetPath); err == nil && len(rel) > 0 && !strings.HasPrefix(rel, ".") {
+		return rel
+	}
+	return targetPath
 }


### PR DESCRIPTION
Adds Support for the following cmd options:
 * RUN
 * RUN.BEFORE
 * RUN.AFTER

RUN is the same as RUN.BEFORE, running *before* your command is executed.
 - Your command only runs if all before commands return exit code zero (0)

RUN.AFTER, as expected, runs *after* your command has finished executing
 - After commands only run if your command returns exit code zero (0)

Execution halts if any RUN returns a non-zero exit code

Your command's environment variables are exported to the invoked command

usage:

    # RUN <cmd> [arg] [arg] ...

Any standard variable assignment values can be used as arguments
 - quoted strings, variable references, etc

chore: Runfile now stores []CmdProvider instead of []*RunCmd
 - Can re-generate RunCmd in different env contexts

chore: Adds new meta token TokenNotNewline
 - Generally indicates non-whitespace content available

bug: Sets config.CurrentRunfile for Primary runfile

---

TODO:
- [x] Update Docs

Relates to #12 

cc: @CircleCode
