### PR TITLE
feat: Add support for Hidden and Private Commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,9 @@ In run, the entire script is executed within a single sub-shell.
  - [Invoking Other Commands & Runfiles](#invoking-other-commands--runfiles)
    - [RUN / RUN.BEFORE / RUN.AFTER Actions](#run--runbefore--runafter-actions)
    - [.RUN / .RUNFILE Attributes](#run--runfile-attributes)
+ - [Hidden / Private Commands](#hidden--private-commands)
+   - [Hidden Commands](#hidden-commands)
+   - [Private Commands](#private-commands)
  - [Script Shells](#script-shells)
    - [Per-Command Shell Config](#per-command-shell-config)
    - [Global Default Shell Config](#global-default-shell-config)
@@ -1439,6 +1442,88 @@ _output_
 $ run test
 
 Hello, World
+```
+
+-----------------------------
+### Hidden / Private Commands
+
+#### Hidden Commands
+
+You can mark a command as _Hidden_ using a leading `.`:
+
+_hidden command example_
+```
+##
+# Prints 'Hello, Newman', then 'Goodbye, now'
+# RUN hello Newman
+test:
+    echo "Goodbye, now"
+
+## Hello command is hidden
+.hello:
+    echo "Hello, ${1:-world}"
+```
+
+Hidden commands don't show up when listing commands:
+
+_list commands_
+```
+$ run list
+
+Commands:
+  ...
+  test       Prints 'Hello, Newman', then 'Goodbye, now'
+```
+
+But they can still be invoked by using their full name, with `.`:
+
+_run hidden command_
+```
+$ run .hello
+
+Hello, world
+```
+
+#### Private Commands
+
+You can mark a command as _Private_ using a leading `!`:
+
+_private command example_
+```
+##
+# Prints 'Hello, Newman', then 'Goodbye, now'
+# RUN hello Newman
+test:
+    echo "Goodbye, now"
+
+## Hello command is private
+!hello:
+    echo "Hello, ${1:-world}"
+```
+
+Private commands don't show up when listing commands:
+
+_list commands_
+```
+$ run list
+
+Commands:
+  ...
+  test       Prints 'Hello, Newman', then 'Goodbye, now'
+```
+
+And they cannot be invoked from outside the Runfile:
+
+_try to run private command_
+```
+$ run hello
+
+run: command not found: hello
+
+$ run '!hello'
+
+run: command not found: !hello
+
 ```
 
 -----------------

--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -381,6 +381,7 @@ func (a *ScopeDParenString) Apply(s *runfile.Scope) string {
 // Cmd wraps a parsed command.
 //
 type Cmd struct {
+	Flags   config.CmdFlags
 	Name    string
 	Config  *CmdConfig
 	Script  []string
@@ -408,6 +409,7 @@ func (a *Cmd) GetCmd(r *runfile.Runfile) *runfile.RunCmd {
 //
 func (a *Cmd) GetCmdEnv(r *runfile.Runfile, env map[string]string) *runfile.RunCmd {
 	cmd := &runfile.RunCmd{
+		Flags:   a.Flags,
 		Name:    a.Name,
 		Scope:   runfile.NewScope(),
 		Script:  a.Script,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,9 +8,35 @@ import (
 	"runtime"
 )
 
+// CmdFlags captures various options for a command
+type CmdFlags int
+
+const (
+	// FlagHidden marks a command as Hidden
+	//
+	FlagHidden CmdFlags = 1 << iota
+
+	// FlagPrivate marks a command as Private
+	//
+	FlagPrivate
+)
+
+// Hidden returns true if flag represents Hidden
+//
+func (c CmdFlags) Hidden() bool {
+	return c&FlagHidden > 0
+}
+
+// Private returns true if flag represents Private
+//
+func (c CmdFlags) Private() bool {
+	return c&FlagPrivate > 0
+}
+
 // Command is an abstraction for a command, allowing us to mix runfile commands and custom comments (help, list, etc).
 //
 type Command struct {
+	Flags   CmdFlags
 	Name    string
 	Title   string
 	Help    func()

--- a/internal/lexer/runereader.go
+++ b/internal/lexer/runereader.go
@@ -2,7 +2,7 @@ package lexer
 
 import "io"
 
-// readerIgnoreCR wraps a RuneReader, filtering errOut '\r'.
+// readerIgnoreCR wraps a RuneReader, filtering out '\r'.
 // Useful for input sources that use '\r'+'\n' for end-of-line.
 //
 type readerIgnoreCR struct {
@@ -19,7 +19,7 @@ func newReaderIgnoreCR(r io.RuneReader) io.RuneReader {
 //
 func (c *readerIgnoreCR) ReadRune() (r rune, size int, err error) {
 	r, size, err = c.r.ReadRune()
-	if size == 1 && r == '\r' {
+	for size == 1 && r == '\r' {
 		r, size, err = c.r.ReadRune()
 	}
 	return

--- a/internal/lexer/runes.go
+++ b/internal/lexer/runes.go
@@ -16,7 +16,7 @@ const (
 	// NOTE: You probably want matchNewline()
 	// runeNewline   = '\n'
 	// runeReturn    = '\r'
-	runeAt        = '@'
+	// runeAt        = '@'
 	runeBang      = '!'
 	runeHash      = '#'
 	runeDollar    = '$'
@@ -42,8 +42,8 @@ const (
 // Single-Rune tokens
 //
 var (
-	singleRunes  = []byte{runeAt, runeBang, runeColon, runeEquals, runeLParen, runeRParen, runeLBrace, runeRBrace, runeLBracket, runeRBracket}
-	singleTokens = []token.Type{TokenAt, TokenBang, TokenColon, TokenEquals, TokenLParen, TokenRParen, TokenLBrace, TokenRBrace, TokenLBracket, TokenRBracket}
+	singleRunes  = []byte{runeColon, runeEquals, runeLParen, runeRParen, runeLBrace, runeRBrace, runeLBracket, runeRBracket}
+	singleTokens = []token.Type{TokenColon, TokenEquals, TokenLParen, TokenRParen, TokenLBrace, TokenRBrace, TokenLBracket, TokenRBracket}
 )
 var mainTokens = map[string]token.Type{
 	"COMMAND": TokenCommand,
@@ -101,6 +101,10 @@ func isAlphaNumUnderDash(r rune) bool {
 
 func isHash(r rune) bool {
 	return r == runeHash
+}
+
+func isDotOrBang(r rune) bool {
+	return r == runeDot || r == runeBang
 }
 
 // isSpaceOrTab matches tab or space

--- a/internal/lexer/runes.go
+++ b/internal/lexer/runes.go
@@ -16,6 +16,7 @@ const (
 	// NOTE: You probably want matchNewline()
 	// runeNewline   = '\n'
 	// runeReturn    = '\r'
+	runeAt        = '@'
 	runeBang      = '!'
 	runeHash      = '#'
 	runeDollar    = '$'
@@ -41,8 +42,8 @@ const (
 // Single-Rune tokens
 //
 var (
-	singleRunes  = []byte{runeColon, runeEquals, runeLParen, runeRParen, runeLBrace, runeRBrace, runeLBracket, runeRBracket}
-	singleTokens = []token.Type{TokenColon, TokenEquals, TokenLParen, TokenRParen, TokenLBrace, TokenRBrace, TokenLBracket, TokenRBracket}
+	singleRunes  = []byte{runeAt, runeBang, runeColon, runeEquals, runeLParen, runeRParen, runeLBrace, runeRBrace, runeLBracket, runeRBracket}
+	singleTokens = []token.Type{TokenAt, TokenBang, TokenColon, TokenEquals, TokenLParen, TokenRParen, TokenLBrace, TokenRBrace, TokenLBracket, TokenRBracket}
 )
 var mainTokens = map[string]token.Type{
 	"COMMAND": TokenCommand,

--- a/internal/lexer/tokens.go
+++ b/internal/lexer/tokens.go
@@ -14,6 +14,7 @@ const (
 	TokenID
 	TokenDotID
 	TokenDashID
+	TokenCommandDefID
 
 	TokenAt          // '@'
 	TokenBang        // '!'

--- a/internal/lexer/tokens.go
+++ b/internal/lexer/tokens.go
@@ -15,31 +15,32 @@ const (
 	TokenDotID
 	TokenDashID
 
-	TokenBang
-	TokenColon
-	TokenComma
+	TokenAt          // '@'
+	TokenBang        // '!'
+	TokenColon       // ':'
+	TokenComma       // ','
 	TokenEquals      // '=' | ':='
 	TokenQMarkEquals // ?=
 
-	TokenDQuote
+	TokenDQuote // '"'
 	TokenDQStringStart
 
-	TokenSQuote
+	TokenSQuote // "'"
 	TokenSQStringStart
 
 	TokenRunes
 	TokenEscapeSequence
 
-	TokenDollar
+	TokenDollar // '$'
 	TokenVarRefStart
 	TokenSubCmdStart
 
-	TokenLParen
-	TokenRParen
-	TokenLBrace
-	TokenRBrace
-	TokenLBracket
-	TokenRBracket
+	TokenLParen   // '('
+	TokenRParen   // ')'
+	TokenLBrace   // '{'
+	TokenRBrace   // '}'
+	TokenLBracket // '['
+	TokenRBracket // ']'
 
 	TokenParenStringStart  // '( '
 	TokenParenStringEnd    // ' )'

--- a/internal/lexer/tokens.go
+++ b/internal/lexer/tokens.go
@@ -16,7 +16,7 @@ const (
 	TokenDashID
 	TokenCommandDefID
 
-	TokenAt          // '@'
+	// TokenAt          // '@'
 	TokenBang        // '!'
 	TokenColon       // ':'
 	TokenComma       // ','

--- a/internal/runfile/command.go
+++ b/internal/runfile/command.go
@@ -431,8 +431,8 @@ func RunHelp() int {
 	if len(cmdName) > 0 {
 		// Show Hidden?
 		//
-		if strings.HasPrefix(cmdName, "@") {
-			cmdName = strings.TrimPrefix(cmdName, "@")
+		if strings.HasPrefix(cmdName, ".") {
+			cmdName = strings.TrimPrefix(cmdName, ".")
 			cmdShowHidden = true
 		}
 		cmdName = strings.ToLower(cmdName)

--- a/internal/runfile/command.go
+++ b/internal/runfile/command.go
@@ -405,12 +405,14 @@ func ListCommands() {
 	_, _ = fmt.Fprintln(config.ErrOut, "Commands:")
 	padLen := 0
 	for _, cmd := range config.CommandList {
-		if len(cmd.Name) > padLen {
+		if !cmd.Flags.Private() && !cmd.Flags.Hidden() && len(cmd.Name) > padLen {
 			padLen = len(cmd.Name)
 		}
 	}
 	for _, cmd := range config.CommandList {
-		_, _ = fmt.Fprintf(config.ErrOut, "  %s%s    %s\n", cmd.Name, strings.Repeat(" ", padLen-len(cmd.Name)), cmd.Title)
+		if !cmd.Flags.Private() && !cmd.Flags.Hidden() {
+			_, _ = fmt.Fprintf(config.ErrOut, "  %s%s    %s\n", cmd.Name, strings.Repeat(" ", padLen-len(cmd.Name)), cmd.Title)
+		}
 	}
 }
 
@@ -421,13 +423,20 @@ func ListCommands() {
 //
 func RunHelp() int {
 	var cmdName string
+	var cmdShowHidden bool
 	if len(os.Args) > 0 {
 		cmdName = os.Args[0]
 		os.Args = os.Args[1:]
 	}
 	if len(cmdName) > 0 {
+		// Show Hidden?
+		//
+		if strings.HasPrefix(cmdName, "@") {
+			cmdName = strings.TrimPrefix(cmdName, "@")
+			cmdShowHidden = true
+		}
 		cmdName = strings.ToLower(cmdName)
-		if c, ok := config.CommandMap[cmdName]; ok {
+		if c, ok := config.CommandMap[cmdName]; ok && !c.Flags.Private() && (!c.Flags.Hidden() || cmdShowHidden) {
 			c.Help()
 			return 0
 		}

--- a/internal/runfile/runfile.go
+++ b/internal/runfile/runfile.go
@@ -64,6 +64,7 @@ type RunCmdConfig struct {
 // RunCmd captures a command.
 //
 type RunCmd struct {
+	Flags   config.CmdFlags
 	Name    string
 	Config  *RunCmdConfig
 	Scope   *Scope

--- a/main.go
+++ b/main.go
@@ -370,8 +370,8 @@ func main() {
 			cmdName, os.Args = os.Args[0], os.Args[1:]
 			// Show Hidden?
 			//
-			if strings.HasPrefix(cmdName, "@") {
-				cmdName = strings.TrimPrefix(cmdName, "@")
+			if strings.HasPrefix(cmdName, ".") {
+				cmdName = strings.TrimPrefix(cmdName, ".")
 				cmdShowHidden = true
 			}
 		} else {

--- a/main.go
+++ b/main.go
@@ -263,6 +263,7 @@ func main() {
 		runCommandsByName := make(map[string]*runfile.RunCmd)
 		for _, cmdProvider := range rf.Cmds {
 			newRunCommand := cmdProvider.GetCmd(rf)
+			newRunCommandFlags := newRunCommand.Flags   // May override later
 			newRunCommandName := newRunCommand.Name     // Un-normalized name used for help
 			name := strings.ToLower(newRunCommand.Name) // normalize
 			// Keep track of which Runfile a command is registered in, to avoid dupes from same file
@@ -294,7 +295,7 @@ func main() {
 						log.Printf("NOTICE: %s:%d command %s overrides command %s defined in %s:%d", newRunCommand.Runfile, newRunCommand.Line, newRunCommand.Name, oldRunCommand.Name, oldRunCommand.Runfile, oldRunCommand.Line)
 					}
 				}
-				// Remove old command, taking note of command name and CommandList index, which will be re-used
+				// Remove old command, taking note of command flags, name and CommandList index, which will be re-used
 				//
 				delete(config.CommandMap, name) // Technically not needed but feels cleaner
 				for i := range config.CommandList {
@@ -303,6 +304,9 @@ func main() {
 						break
 					}
 				}
+				// For flags, first registered command wins
+				//
+				newRunCommandFlags = firstRunCommand.Flags
 				// For help display, first registered command wins
 				//
 				newRunCommandName = firstRunCommand.Name
@@ -317,6 +321,7 @@ func main() {
 			runCommandsByNameForFile[name] = newRunCommand
 			runCommandsByName[name] = newRunCommand
 			cmd := &config.Command{
+				Flags: newRunCommandFlags,
 				Name:  newRunCommandName,
 				Title: newRunCommand.Title(),
 				Help:  func(c *runfile.RunCmd) func() { return func() { runfile.ShowCmdHelp(c) } }(newRunCommand),
@@ -345,6 +350,7 @@ func main() {
 	// Determine which command to run
 	//
 	var cmdName string
+	var cmdShowHidden bool
 	if config.MainMode {
 		// In main mode, we defer parsing args to the command
 		//
@@ -362,6 +368,12 @@ func main() {
 		}
 		if len(os.Args) > 0 {
 			cmdName, os.Args = os.Args[0], os.Args[1:]
+			// Show Hidden?
+			//
+			if strings.HasPrefix(cmdName, "@") {
+				cmdName = strings.TrimPrefix(cmdName, "@")
+				cmdShowHidden = true
+			}
 		} else {
 			//
 			// Default (no command) action
@@ -384,11 +396,12 @@ func main() {
 		}
 	}
 	// Run command, if present, else error
+	// Hidden == not present unless command invoked with `@NAME`
 	//
 	cmdName = strings.ToLower(cmdName) // normalize
 	var cmd *config.Command
 	var ok bool
-	if cmd, ok = config.CommandMap[cmdName]; !ok {
+	if cmd, ok = config.CommandMap[cmdName]; !ok || cmd.Flags.Private() || (cmd.Flags.Hidden() && !cmdShowHidden) {
 		log.Printf("command not found: %s", cmdName)
 		runfile.ListCommands()
 		showUsageHint()


### PR DESCRIPTION
You can mark a command as hidden with '.':

    .hidden:
        echo "This command is hidden"

* Can be invoked by command config RUN actions
  * RUN actions do not need to use '.'
* Will not show in CLI list of available commands
* Can still be invoked via CLI using '.name'

You can mark a command as private with '!':

    !private:
        echo "This command is private"

* Can only be invoked by command config RUN actions
  * RUN actions do not need to use '!'
* Will not show in CLI list of available commands
* Cannot be invoked from CLI

---

TODO
 - [x] Update Docs
