### PR TITLE
doc: Mention example runfiles available in link to homepage

### DIFF
--- a/main.go
+++ b/main.go
@@ -63,7 +63,7 @@ func showRunHelp() {
 	fmt.Fprintln(config.ErrOut, "        -f | -f=true | -f=false")
 	fmt.Fprintln(config.ErrOut, "  Short options cannot be combined")
 	if !config.ShebangMode {
-		fmt.Fprintln(config.ErrOut, "\nLearn more about run at https://github.com/TekWizely/run") // Leading \n
+		fmt.Fprintln(config.ErrOut, "\nLearn more about run (including example runfiles) at https://github.com/TekWizely/run") // Leading \n
 	}
 }
 


### PR DESCRIPTION
Updates the standard "Learn more" message to mention that example runfiles are available at the project homepage

---

Closes #80 
cc: @Gys 
